### PR TITLE
update sass

### DIFF
--- a/vanilla-setup/src/scss/createRecipe.scss
+++ b/vanilla-setup/src/scss/createRecipe.scss
@@ -1,4 +1,4 @@
-@import './variables.scss';
+@use './variables' as *;
 
 body {
   font-family: $font-stack;

--- a/vanilla-setup/src/scss/index.scss
+++ b/vanilla-setup/src/scss/index.scss
@@ -1,4 +1,4 @@
-@import './variables.scss';
+@use './variables' as *;
 
 body {
   margin: 0;

--- a/vanilla-setup/src/scss/variables.scss
+++ b/vanilla-setup/src/scss/variables.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 // Färger
 $primary-color: #5b184b;
 $secondary-color: #ffffff; 
@@ -5,8 +6,8 @@ $text-color: #000;
 $error-color: #da2232;
 
 // Extra färger för olika nivåer av text
-$text-light: lighten($text-color, 40%);
-$text-border: lighten($text-color, 50%);
+$text-light: color.adjust($text-color, $lightness: 40%);
+$text-border: color.adjust($text-color, $lightness: 50%);
 
 // Typsnitt
 $font-stack: 'Poppins', sans-serif;


### PR DESCRIPTION
In this commit I fixed the Sass deprecation warnings by importing sass:color and replacing syntax that will be removed in Dart Sass 3.0.0.